### PR TITLE
Potential fix ensures child suites marked to run multiple times do so.

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1290,6 +1290,8 @@ munit_test_runner_run_suite(MunitTestRunner* runner,
   size_t pre_l;
   char* pre = munit_maybe_concat(&pre_l, (char*) prefix, (char*) suite->prefix);
 
+  runner->suite = suite;
+
   /* Run the tests. */
   for (const MunitTest* test = suite->tests ; test != NULL && test->test != NULL ; test++) {
     if (runner->tests != NULL) { /* Specific tests were requested on the CLI */


### PR DESCRIPTION
I have test suites like this:

```
static MunitSuite other_suites[] = {
    {
        "/morton-tests-randomized",
        tests_randomized,
        NULL,
        1024,
        MUNIT_SUITE_OPTION_NONE
    },
    { NULL, NULL, NULL, 0, MUNIT_SUITE_OPTION_NONE }
};


static const MunitSuite suite = {
    "/morton-tests",
    tests_static,
    other_suites,
    1,
    MUNIT_SUITE_OPTION_NONE,
};
```

However, without this change, the tests under "/morton-tests-randomized" are only run once, not 1024 times as I requested.

I am VERY suspicious about the fact that this worked at all. While it did exactly what I wanted, it looks like one of those really suspicious one-line changes that while it fixes one thing it also fscks everything else. I checked everywhere for bits of code similar to `runner->suite` and the only ones I found are the one passed in through `munit_test_runner_run` and the bit of `munit_test_runner_exec` which checks the number of iterations to run a test for. So I think it's safe. Probably?

It seems mildly ironic that munit itself doesn't have any unit tests I can run to try and catch this.

EDIT: To clarify, when the ROOT test suite (the one simply named `suite` in the above sample) has its iterations field set to a number greater than one, all of the tests in all suites are run multiple times as expected. A consequence of this change, I guess, kinda unwanted? Would be that if the root `suite` had its iterations set to a number `n` and the child suite had `m` iterations, we wouldn't get `n * m` iterations of the child suite, only `m`. I'm gonna try to look into how to fix that tomorrow.

EDIT 2: Having found another potential fix, I have realized a PR is a terrible place to put this. I am moving this to an issue.