### PR TITLE
Add meson.build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,10 +134,18 @@ matrix:
 before_install:
 - if [ -n "${C_COMPILER}" ]; then export CC="${C_COMPILER}"; fi
 - if [ "${C_COMPILER}" = "pgcc" ]; then wget -q -O /dev/stdout 'https://raw.githubusercontent.com/nemequ/pgi-travis/master/install-pgi.sh' | /bin/sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pyenv local 3.6; fi
+- export PATH="$(pwd)/ninja:${PATH}"
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install python3 ninja; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d ninja; fi
+- pip3 install meson
 
 script:
  - make CC="${CC}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"
  - make test
+ - meson build
+ - ninja -Cbuild
+ - ninja -Cbuild test
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Features µnit does not currently include, but some day may include
  * [TAP](http://testanything.org/) support; feel free to discuss in
    [issue #1](https://github.com/nemequ/munit/issues/1)
 
+# Include into your project with meson
+
+In your `subprojects` folder put a `munit.wrap` file containing:
+
+```
+[wrap-git]
+directory=munit
+url=https://github.com/nemequ/munit/
+revision=head
+```
+
+Then you can use a subproject fallback when you include munit as a
+dependency to your project: `dependency('munit', fallback: ['munit', 'munit_dep'])`
+
 ## Documentation
 
 See [the µnit web site](https://nemequ.github.io/munit).

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,37 @@
+project('munit', 'c')
+
+conf_data = configuration_data()
+conf_data.set('version', '0.2.0')
+
+add_project_arguments('-std=c99', language : 'c')
+
+cc  = meson.get_compiler('c')
+
+root_include = include_directories('.')
+
+munit = library('munit',
+    ['munit.c'],
+    install: meson.is_subproject())
+
+if meson.is_subproject()
+  munit_dep = declare_dependency(
+      include_directories : root_include,
+      link_with : munit)
+else
+  # standalone install
+  install_headers('munit.h')
+
+  pkg = import('pkgconfig')
+  pkg.generate(name: 'munit',
+                description: 'µnit Testing Library for C',
+                version: conf_data.get('version'),
+                libraries: munit)
+
+  # compile the demo project
+  munit_example_src = files('example.c')
+  munit_example = executable('munit_example', munit_example_src,
+              include_directories: root_include,
+              link_with: munit)
+
+  test('munit example test', munit_example)
+endif


### PR DESCRIPTION
This meson.build file allows you to create a pkg-config and munit library when compiled directly, and include munit as a subproject from external meson projects using subproject() capabilities. See https://github.com/eintw1ck/cha2slide/blob/master/src/meson.build#L75 for an example of how it's used (look for pkg-config version, then vendor if not found by pkg-config). Obviously for munit installing it as a library doesn't make much sense but being able to just set the url to this git repo is very useful (can only be done if the project has a meson.build).