### PR TITLE
README: change size of header

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features µnit does not currently include, but some day may include
  * [TAP](http://testanything.org/) support; feel free to discuss in
    [issue #1](https://github.com/nemequ/munit/issues/1)
 
-# Include into your project with meson
+### Include into your project with meson
 
 In your `subprojects` folder put a `munit.wrap` file containing:
 


### PR DESCRIPTION
The 'Include into your project with meson' header should be smaller than the 'Features' header