### PR TITLE
Add munit_rand_uint32_range()

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1009,6 +1009,17 @@ munit_rand_int_range(int min, int max) {
   return min + munit_rand_at_most(0, (munit_uint32_t) range);
 }
 
+munit_uint32_t
+munit_rand_uint32_range(munit_uint32_t min, munit_uint32_t max) {
+
+  munit_uint32_t range = (munit_uint32_t) max - (munit_uint32_t) min;
+
+  if (min > max)
+    return munit_rand_uint32_range(max, min);
+
+  return min + munit_rand_at_most(0, (munit_uint32_t) range);
+}
+
 double
 munit_rand_double(void) {
   munit_uint32_t old, state;

--- a/munit.h
+++ b/munit.h
@@ -396,6 +396,7 @@ void* munit_malloc_ex(const char* filename, int line, size_t size);
 
 void munit_rand_seed(munit_uint32_t seed);
 munit_uint32_t munit_rand_uint32(void);
+munit_uint32_t munit_rand_uint32_range(munit_uint32_t min, munit_uint32_t max);
 int munit_rand_int_range(int min, int max);
 double munit_rand_double(void);
 void munit_rand_memory(size_t size, munit_uint8_t buffer[MUNIT_ARRAY_PARAM(size)]);


### PR DESCRIPTION
Added because calling `munit_rand_int_range(0, 0xffffffff);` was only returning 0 or -1.

Not sure if you will actually accept this, but I'd love to help with documentation if you actually want this function or something similar