### PR TITLE
build: invert install condition for libmunit.so

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ root_include = include_directories('.')
 
 munit = library('munit',
     ['munit.c'],
-    install: meson.is_subproject())
+    install: not meson.is_subproject())
 
 if meson.is_subproject()
   munit_dep = declare_dependency(


### PR DESCRIPTION
When munit is built standalone, the .so file will not get copied on `ninja
install`, which goes counter to the idea of a standalone installation.