### PR TITLE
Work-around error with stderr buffer file creation on Windows

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -154,7 +154,7 @@ static MUNIT_THREAD_LOCAL jmp_buf munit_error_jmp_buf;
 #endif
 
 /* At certain warning levels, mingw will trigger warnings about
- * suggesting the format attribute, which we've explicity *not* set
+ * suggesting the format attribute, which we've explicitly *not* set
  * because it will then choke on our attempts to use the MS-specific
  * I64 modifier for size_t (which we have to use since MSVC doesn't
  * support the C99 z modifier). */
@@ -298,7 +298,7 @@ munit_malloc_ex(const char* filename, int line, size_t size) {
  * sync. */
 
 /* Clocks (v1)
- * Portable Snippets - https://gitub.com/nemequ/portable-snippets
+ * Portable Snippets - https://github.com/nemequ/portable-snippets
  * Created by Evan Nemerson <evan@nemerson.com>
  *
  *   To the extent possible under law, the authors have waived all
@@ -1072,7 +1072,7 @@ munit_print_time(FILE* fp, munit_uint64_t nanoseconds) {
 }
 #endif
 
-/* Add a paramter to an array of parameters. */
+/* Add a parameter to an array of parameters. */
 static MunitResult
 munit_parameters_add(size_t* params_size, MunitParameter* params[MUNIT_ARRAY_PARAM(*params_size)], char* name, char* value) {
   *params = realloc(*params, sizeof(MunitParameter) * (*params_size + 2));
@@ -1119,7 +1119,7 @@ munit_maybe_concat(size_t* len, char* prefix, char* suffix) {
   return res;
 }
 
-/* Possbily free a string returned by munit_maybe_concat. */
+/* Possibly free a string returned by munit_maybe_concat. */
 static void
 munit_maybe_free_concat(char* s, const char* prefix, const char* suffix) {
   if (prefix != s && suffix != s)
@@ -1650,7 +1650,7 @@ munit_test_runner_run_test(MunitTestRunner* runner,
 }
 
 /* Recurse through the suite and run all the tests.  If a list of
- * tests to run was provied on the command line, run only those
+ * tests to run was provided on the command line, run only those
  * tests.  */
 static void
 munit_test_runner_run_suite(MunitTestRunner* runner,


### PR DESCRIPTION
This was already mentioned by me in #33.

Feel free to ask any questions or request changes.
It's absolutely no problem for me to explain and/or fix if needed.

A couple of related links:

https://stackoverflow.com/questions/6247148/tmpfile-on-windows-7-x64
https://issues.dlang.org/show_bug.cgi?id=7537
