### PR TITLE
Replace `exit` by `_exit` in child.

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1366,7 +1366,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
           if (stderr_buf != NULL) {
             munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to write to pipe");
           }
-          exit(EXIT_FAILURE);
+          _exit(EXIT_FAILURE);
         }
         bytes_written += write_res;
       } while ((size_t) bytes_written < sizeof(report));
@@ -1375,7 +1375,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
         fclose(stderr_buf);
       close(pipefd[1]);
 
-      exit(EXIT_SUCCESS);
+      _exit(EXIT_SUCCESS);
     } else if (fork_pid == -1) {
       close(pipefd[0]);
       close(pipefd[1]);


### PR DESCRIPTION
See
https://stackoverflow.com/questions/5422831/what-is-the-difference-between-using-exit-exit-in-a-conventional-linux-fo
and section 25.4 in `The Linux Programming Interface` by Michael
Kerrisk.

The `exit` library call was causing our tests to become extremely slow
when running with ASAN on arm64 and ppc64le architectures. Replacing with
`_exit` fixed the issue.
Haven't exactly pinpointed the issue, but the problem is related to the
child and the parent both flushing the parent's stdio buffers and
calling the exit handlers.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>