### PR TITLE
Fixes a small mistake in the definitions of assert alias assert_ptr_null 

### DIFF
--- a/munit.h
+++ b/munit.h
@@ -513,7 +513,7 @@ int munit_suite_main_custom(const MunitSuite* suite,
 #define assert_memory_not_equal(size, a, b) munit_assert_memory_not_equal(size, a, b)
 #define assert_ptr_equal(a, b) munit_assert_ptr_equal(a, b)
 #define assert_ptr_not_equal(a, b) munit_assert_ptr_not_equal(a, b)
-#define assert_ptr_null(ptr) munit_assert_null_equal(ptr)
+#define assert_ptr_null(ptr) munit_assert_ptr_null(ptr)
 #define assert_ptr_not_null(ptr) munit_assert_not_null(ptr)
 
 #define assert_null(ptr) munit_assert_null(ptr)


### PR DESCRIPTION
This fixes a small mistake in the definitions of assert aliases.
munit_assert_null_equal is not defined, assert_ptr_null should refer to munit_assert_ptr_null which is defined