### PR TITLE
Add some extra warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ endif
 
 ifneq ($(CC),pgcc)
         ifeq ($(EXTRA_WARNINGS),y)
-                CFLAGS+=-Wall -Wextra -Werror -Wshadow -Wcast-qual
+                CFLAGS+=-Wall -Wextra -Werror -Wshadow -Wcast-qual \
+                        -Wswitch-default
         endif
 
         ifeq ($(ASAN),y)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 ifneq ($(CC),pgcc)
         ifeq ($(EXTRA_WARNINGS),y)
-                CFLAGS+=-Wall -Wextra -Werror
+                CFLAGS+=-Wall -Wextra -Werror -Wshadow
         endif
 
         ifeq ($(ASAN),y)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 ifneq ($(CC),pgcc)
         ifeq ($(EXTRA_WARNINGS),y)
-                CFLAGS+=-Wall -Wextra -Werror -Wshadow
+                CFLAGS+=-Wall -Wextra -Werror -Wshadow -Wcast-qual
         endif
 
         ifeq ($(ASAN),y)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 ifneq ($(CC),pgcc)
         ifeq ($(EXTRA_WARNINGS),y)
                 CFLAGS+=-Wall -Wextra -Werror -Wshadow -Wcast-qual \
-                        -Wswitch-default
+                        -Wswitch-default -Wsign-conversion
         endif
 
         ifeq ($(ASAN),y)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 ifneq ($(CC),pgcc)
         ifeq ($(EXTRA_WARNINGS),y)
                 CFLAGS+=-Wall -Wextra -Werror -Wshadow -Wcast-qual \
-                        -Wswitch-default -Wsign-conversion
+                        -Wswitch-default -Wsign-conversion -Wunused-result
         endif
 
         ifeq ($(ASAN),y)

--- a/munit.c
+++ b/munit.c
@@ -581,8 +581,8 @@ psnip_clock_wall_get_time (struct PsnipClockTimespec* res) {
   if (gettimeofday(&tv, NULL) != 0)
     return -6;
 
-  res->seconds = tv.tv_sec;
-  res->nanoseconds = tv.tv_usec * 1000;
+  res->seconds = (psnip_uint64_t) tv.tv_sec;
+  res->nanoseconds = (psnip_uint64_t) (tv.tv_usec * 1000);
 #else
   return -2;
 #endif

--- a/munit.c
+++ b/munit.c
@@ -723,9 +723,11 @@ psnip_clock_get_precision (enum PsnipClockType clock_type) {
       return psnip_clock_cpu_get_precision ();
     case PSNIP_CLOCK_TYPE_WALL:
       return psnip_clock_wall_get_precision ();
+    default:
+      PSNIP_CLOCK_UNREACHABLE();
+      break;
   }
 
-  PSNIP_CLOCK_UNREACHABLE();
   return 0;
 }
 
@@ -742,6 +744,8 @@ psnip_clock_get_time (enum PsnipClockType clock_type, struct PsnipClockTimespec*
       return psnip_clock_cpu_get_time (res);
     case PSNIP_CLOCK_TYPE_WALL:
       return psnip_clock_wall_get_time (res);
+    default:
+      return -1;
   }
 
   return -1;

--- a/munit.c
+++ b/munit.c
@@ -259,7 +259,13 @@ munit_log_errno(MunitLogLevel level, FILE* fp, const char* msg) {
   munit_error_str[0] = '\0';
 
 #if !defined(_WIN32)
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L) && !defined(_GNU_SOURCE)
   strerror_r(errno, munit_error_str, MUNIT_STRERROR_LEN);
+#else
+  char *s = strerror_r(errno, munit_error_str, MUNIT_STRERROR_LEN);
+  munit_logf_internal(level, fp, "%s: %s (%d)", msg, s, errno);
+  return ;
+#endif
 #else
   strerror_s(munit_error_str, MUNIT_STRERROR_LEN, errno);
 #endif

--- a/munit.c
+++ b/munit.c
@@ -1090,9 +1090,9 @@ munit_parameters_add(size_t* params_size, MunitParameter* params[MUNIT_ARRAY_PAR
 
 /* Concatenate two strings, but just return one of the components
  * unaltered if the other is NULL or "". */
-static char*
-munit_maybe_concat(size_t* len, char* prefix, char* suffix) {
-  char* res;
+static const char*
+munit_maybe_concat(size_t* len, const char* prefix, const char* suffix, char **concat_name) {
+  const char* res;
   size_t res_l;
   const size_t prefix_l = prefix != NULL ? strlen(prefix) : 0;
   const size_t suffix_l = suffix != NULL ? strlen(suffix) : 0;
@@ -1106,24 +1106,20 @@ munit_maybe_concat(size_t* len, char* prefix, char* suffix) {
     res = prefix;
     res_l = prefix_l;
   } else {
+    char *new_res;
     res_l = prefix_l + suffix_l;
-    res = malloc(res_l + 1);
-    memcpy(res, prefix, prefix_l);
-    memcpy(res + prefix_l, suffix, suffix_l);
-    res[res_l] = 0;
+    new_res = malloc(res_l + 1);
+    memcpy(new_res, prefix, prefix_l);
+    memcpy(new_res + prefix_l, suffix, suffix_l);
+    new_res[res_l] = 0;
+    *concat_name = new_res;
+    res = (const char *)new_res;
   }
 
   if (len != NULL)
     *len = res_l;
 
   return res;
-}
-
-/* Possbily free a string returned by munit_maybe_concat. */
-static void
-munit_maybe_free_concat(char* s, const char* prefix, const char* suffix) {
-  if (prefix != s && suffix != s)
-    free(s);
 }
 
 /* Cheap string hash function, just used to salt the PRNG. */
@@ -1553,7 +1549,8 @@ static void
 munit_test_runner_run_test(MunitTestRunner* runner,
                            const MunitTest* test,
                            const char* prefix) {
-  char* test_name = munit_maybe_concat(NULL, (char*) prefix, (char*) test->name);
+  char *concat_name = NULL;
+  const char* test_name = munit_maybe_concat(NULL, prefix, test->name, &concat_name);
   /* The array of parameters to pass to
    * munit_test_runner_run_test_with_params */
   MunitParameter* params = NULL;
@@ -1646,7 +1643,8 @@ munit_test_runner_run_test(MunitTestRunner* runner,
     free(wild_params);
   }
 
-  munit_maybe_free_concat(test_name, prefix, test->name);
+  if (concat_name != NULL)
+    free(concat_name);
 }
 
 /* Recurse through the suite and run all the tests.  If a list of
@@ -1657,7 +1655,8 @@ munit_test_runner_run_suite(MunitTestRunner* runner,
                             const MunitSuite* suite,
                             const char* prefix) {
   size_t pre_l;
-  char* pre = munit_maybe_concat(&pre_l, (char*) prefix, (char*) suite->prefix);
+  char *concat_name = NULL;
+  const char* pre = munit_maybe_concat(&pre_l, prefix, suite->prefix, &concat_name);
   const MunitTest* test;
   const char** test_name;
   const MunitSuite* child_suite;
@@ -1688,7 +1687,8 @@ munit_test_runner_run_suite(MunitTestRunner* runner,
 
  cleanup:
 
-  munit_maybe_free_concat(pre, prefix, suite->prefix);
+  if (concat_name != NULL)
+    free(concat_name);
 }
 
 static void
@@ -1763,7 +1763,8 @@ munit_arguments_find(const MunitArgument arguments[], const char* name) {
 static void
 munit_suite_list_tests(const MunitSuite* suite, munit_bool show_params, const char* prefix) {
   size_t pre_l;
-  char* pre = munit_maybe_concat(&pre_l, (char*) prefix, (char*) suite->prefix);
+  char *concat_name = NULL;
+  const char* pre = munit_maybe_concat(&pre_l, prefix, suite->prefix, &concat_name);
   const MunitTest* test;
   const MunitParameterEnum* params;
   munit_bool first;
@@ -1806,7 +1807,8 @@ munit_suite_list_tests(const MunitSuite* suite, munit_bool show_params, const ch
     munit_suite_list_tests(child_suite, show_params, pre);
   }
 
-  munit_maybe_free_concat(pre, prefix, suite->prefix);
+  if (concat_name != NULL)
+    free(concat_name);
 }
 
 static munit_bool

--- a/munit.c
+++ b/munit.c
@@ -1293,10 +1293,10 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
   munit_bool first;
   const MunitParameter* param;
   FILE* stderr_buf;
+  volatile int orig_stderr;
 #if !defined(MUNIT_NO_FORK)
   int pipefd[2];
   pid_t fork_pid;
-  int orig_stderr;
   ssize_t bytes_written = 0;
   ssize_t write_res;
   ssize_t bytes_read = 0;
@@ -1423,7 +1423,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
 #endif
   {
 #if !defined(MUNIT_NO_BUFFER)
-    const volatile int orig_stderr = munit_replace_stderr(stderr_buf);
+    orig_stderr = munit_replace_stderr(stderr_buf);
 #endif
 
 #if defined(MUNIT_THREAD_LOCAL)


### PR DESCRIPTION
Hi @nemequ !

I've added some options to the `EXTRA_WARNINGS` - and I also fixed the warnings I've found in my build environment.

Tested platforms:
* M1 Mac(clang 13.1.6)
* mingw64 (gcc 11.2; there are some VLA-related warnings, but that's fine)
* linux 64 bit (clang10.0, gcc 9.4)

