### PR TITLE
CMake support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /example
 /*.exe
 /*.dll
+/[Bb]uild/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required (VERSION 3.27)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+
+project (munit
+  LANGUAGES C
+  VERSION 0.2.0
+  HOMEPAGE_URL "https://github.com/nemequ/munit"
+  DESCRIPTION "µnit is a small testing framework for C ")
+
+find_package (OpenMP)
+
+add_library (munit munit.c)
+
+include(GNUInstallDirs)
+
+target_include_directories (munit
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties (munit
+  PROPERTIES
+    C_STANDARD 99
+    C_EXTENSIONS OFF
+    C_STANDARD_REQUIRED ON
+    PUBLIC_HEADER "munit.h"
+    DEBUG_POSTFIX "d")
+
+target_link_libraries (munit
+  PUBLIC
+    $<IF:$<TARGET_EXISTS:OpenMP::OpenMP_C>,OpenMP::OpenMP_C,"">)
+
+install (TARGETS munit
+         EXPORT
+           munit
+         PUBLIC_HEADER
+           DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+         LIBRARY
+           DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+         CONFIGURATIONS
+          "RELEASE;DEBUG"
+         EXPORT_LINK_INTERFACE_LIBRARIES)
+
+export (TARGETS munit
+  NAMESPACE
+    MUnit::
+  FILE
+    FindMunit-Config.cmake
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required (VERSION 3.27)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
-
 project (munit
   LANGUAGES C
   VERSION 0.2.0
@@ -12,7 +10,8 @@ find_package (OpenMP)
 
 add_library (munit munit.c)
 
-include(GNUInstallDirs)
+include (GNUInstallDirs)
+include (CMakePackageConfigHelpers)
 
 target_include_directories (munit
   PUBLIC
@@ -32,11 +31,32 @@ target_link_libraries (munit
   PUBLIC
     $<IF:$<TARGET_EXISTS:OpenMP::OpenMP_C>,OpenMP::OpenMP_C,"">)
 
-install (TARGETS munit
-         EXPORT munit
-         RUNTIME DESTINATION bin
-         LIBRARY DESTINATION lib
-         ARCHIVE DESTINATION lib)
+install (
+  TARGETS munit
+  EXPORT munit-targets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                      "${CMAKE_INSTALL_INCLUDEDIR}/munit"
+)
 
-install (EXPORT munit DESTINATION share NAMESPACE MUnit::)
+install (
+  EXPORT munit-targets
+  FILE munit-targets.cmake
+  NAMESPACE MUnit::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/munit"
+)
+
+configure_package_config_file(
+  "cmake/Config.cmake.in"
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/munit-config.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/munit"
+)
+
 install (FILES munit.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,21 +24,19 @@ set_target_properties (munit
     C_STANDARD 99
     C_EXTENSIONS OFF
     C_STANDARD_REQUIRED ON
-    DEBUG_POSTFIX "d"
-    RELWITHDEBINFO_POSTFIX "rd")
+    DEBUG_POSTFIX "_d"
+    RELWITHDEBINFO_POSTFIX "_rd"
+    MINSIZEREL_POSTFIX "_msr")
 
 target_link_libraries (munit
   PUBLIC
     $<IF:$<TARGET_EXISTS:OpenMP::OpenMP_C>,OpenMP::OpenMP_C,"">)
 
 install (TARGETS munit
-         EXPORT
-          munit
-         DESTINATION
-          ${CMAKE_INSTALL_LIBDIR}
-         LIBRARY
-         CONFIGURATIONS
-          "Debug;Release")
+         EXPORT munit
+         RUNTIME DESTINATION bin
+         LIBRARY DESTINATION lib
+         ARCHIVE DESTINATION lib)
 
-install (EXPORT munit DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/munit)
+install (EXPORT munit DESTINATION share NAMESPACE MUnit::)
 install (FILES munit.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library (munit munit.c)
 include(GNUInstallDirs)
 
 target_include_directories (munit
-  INTERFACE
+  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -24,8 +24,8 @@ set_target_properties (munit
     C_STANDARD 99
     C_EXTENSIONS OFF
     C_STANDARD_REQUIRED ON
-    PUBLIC_HEADER "munit.h"
-    DEBUG_POSTFIX "d")
+    DEBUG_POSTFIX "d"
+    RELWITHDEBINFO_POSTFIX "rd")
 
 target_link_libraries (munit
   PUBLIC
@@ -33,18 +33,12 @@ target_link_libraries (munit
 
 install (TARGETS munit
          EXPORT
-           munit
-         PUBLIC_HEADER
-           DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+          munit
+         DESTINATION
+          ${CMAKE_INSTALL_LIBDIR}
          LIBRARY
-           DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
          CONFIGURATIONS
-          "RELEASE;DEBUG"
-         EXPORT_LINK_INTERFACE_LIBRARIES)
+          "Debug;Release")
 
-export (TARGETS munit
-  NAMESPACE
-    MUnit::
-  FILE
-    FindMunit-Config.cmake
-  EXPORT_LINK_INTERFACE_LIBRARIES)
+install (EXPORT munit DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/munit)
+install (FILES munit.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Now CMake can find MUnit with `find_package`.
CMake can use this project as git submodule / cmake subdirectory.