### PR TITLE
Fix build when both `MUNIT_NO_BUFFER` and `MUNIT_NO_FORK` are defined

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1251,7 +1251,7 @@ munit_test_runner_print_color(const MunitTestRunner* runner, const char* string,
     fputs(string, MUNIT_OUTPUT_FILE);
 }
 
-#if !defined(MUNIT_NO_BUFFER)
+#if !defined(MUNIT_NO_BUFFER) || !defined(MUNIT_NO_FORK)
 static int
 munit_replace_stderr(FILE* stderr_buf) {
   if (stderr_buf != NULL) {


### PR DESCRIPTION
`munit_replace_stderr` is used here, surrounded by `#if !defined(MUNIT_NO_BUFFER)`:

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1426

It is also used here, surrounded by `#if !defined(MUNIT_NO_FORK)`:

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1355

This PR ensures that `munit_replace_stderr` is available when `MUNIT_NO_BUFFER` and `MUNIT_NO_FORK` are both defined.