### PR TITLE
Ensure tests fail on stderr and pipe errors

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -1334,6 +1334,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
 #endif
   if (stderr_buf == NULL) {
     munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to create buffer for stderr");
+    report.errored++;
     result = MUNIT_ERROR;
     goto print_result;
   }
@@ -1344,6 +1345,7 @@ munit_test_runner_run_test_with_params(MunitTestRunner* runner, const MunitTest*
     pipefd[1] = -1;
     if (pipe(pipefd) != 0) {
       munit_log_errno(MUNIT_LOG_ERROR, stderr, "unable to create pipe");
+      report.errored++;
       result = MUNIT_ERROR;
       goto print_result;
     }


### PR DESCRIPTION
Currently, the munit process exits with a success code, even if there is an error creating the buffer for `stderr` or an error creating the pipe to the forked process. This PR ensures that `report.errored` is incremented on both those errors, ensuring the process exits with an error code.

Note that the appropriate `report` counter is currently incremented everywhere else the test result is updated:

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1205-L1226

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1385-L1386

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1431-L1432