### PR TITLE
Avoid divide-by-zero in `munit_rand_state_at_most` when `max` is zero

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -962,6 +962,7 @@ munit_rand_memory(size_t size, munit_uint8_t data[MUNIT_ARRAY_PARAM(size)]) {
   } while (!munit_atomic_cas(&munit_rand_state, &old, state));
 }
 
+/* max cannot be zero. */
 static munit_uint32_t
 munit_rand_state_at_most(munit_uint32_t* state, munit_uint32_t salt, munit_uint32_t max) {
   /* We want (UINT32_MAX + 1) % max, which in unsigned arithmetic is the same
@@ -983,6 +984,7 @@ munit_rand_state_at_most(munit_uint32_t* state, munit_uint32_t salt, munit_uint3
   return x % max;
 }
 
+/* max cannot be zero. */
 static munit_uint32_t
 munit_rand_at_most(munit_uint32_t salt, munit_uint32_t max) {
   munit_uint32_t old, state;
@@ -1618,7 +1620,10 @@ munit_test_runner_run_test(MunitTestRunner* runner,
          * running a single test, but we don't want every test with
          * the same number of parameters to choose the same parameter
          * number, so use the test name as a primitive salt. */
-        pidx = munit_rand_at_most(munit_str_hash(test_name), possible - 1);
+        if (possible > 1)
+          pidx = munit_rand_at_most(munit_str_hash(test_name), possible - 1);
+        else
+          pidx = 0;
         if (MUNIT_UNLIKELY(munit_parameters_add(&params_l, &params, pe->name, pe->values[pidx]) != MUNIT_OK))
           goto cleanup;
       } else {

--- a/munit.c
+++ b/munit.c
@@ -998,10 +998,14 @@ munit_rand_at_most(munit_uint32_t salt, munit_uint32_t max) {
 
 int
 munit_rand_int_range(int min, int max) {
-  munit_uint64_t range = (munit_uint64_t) max - (munit_uint64_t) min;
+  munit_uint64_t range;
 
-  if (min > max)
+  if (min == max)
+    return min;
+  else if (min > max)
     return munit_rand_int_range(max, min);
+
+  range = (munit_uint64_t) max - (munit_uint64_t) min;
 
   if (range > (~((munit_uint32_t) 0U)))
     range = (~((munit_uint32_t) 0U));


### PR DESCRIPTION
The following expression will trigger a divide-by-zero error when `max` is zero:

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L971

This can occur in two places. The first is `munit_rand_int_range`, when `min` equals `max`:

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1001-L1009

The second is in `munit_test_runner_run_test`, when a parameter has a single value (`possible` equals `1`).

https://github.com/nemequ/munit/blob/fbbdf1467eb0d04a6ee465def2e529e4c87f2118/munit.c#L1617

Put checks in place to avoid calling `munit_rand_state_at_most` with a `max` of zero.

This is the same issue referenced in https://github.com/nemequ/munit/issues/30 and https://github.com/nemequ/munit/pull/59.