### PR TITLE
Fix msvc and clang C99 builds

### DIFF
--- a/munit.c
+++ b/munit.c
@@ -777,11 +777,13 @@ munit_clock_get_elapsed(struct PsnipClockTimespec* start, struct PsnipClockTimes
  * important that it be reproducible, so bug reports have a better
  * chance of being reproducible. */
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__) && !defined(__EMSCRIPTEN__) && (!defined(__GNUC_MINOR__) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8))
-#  define HAVE_STDATOMIC
-#elif defined(__clang__)
-#  if __has_extension(c_atomic)
-#    define HAVE_CLANG_ATOMICS
+#if __STDC_VERSION__ >= 201112L
+#  if defined(__STDC_VERSION__) && !defined(__STDC_NO_ATOMICS__) && !defined(__EMSCRIPTEN__) && (!defined(__GNUC_MINOR__) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8))
+#    define HAVE_STDATOMIC
+#  elif defined(__clang__)
+#    if __has_extension(c_atomic)
+#      define HAVE_CLANG_ATOMICS
+#    endif
 #  endif
 #endif
 

--- a/munit.h
+++ b/munit.h
@@ -131,7 +131,7 @@ extern "C" {
 #  define MUNIT_UNUSED
 #endif
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && !defined(__PGI)
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && !defined(__PGI) && !defined(_MSC_VER)
 #  define MUNIT_ARRAY_PARAM(name) name
 #else
 #  define MUNIT_ARRAY_PARAM(name)


### PR DESCRIPTION
The Microsoft compiler doesn't support variable length arrays, so avoid using them there. And seems like there's an issue with clang where `__has_extension(c_atomic)` is true even when it's set to use C99, then complains about `_Atomic` being a C11 extension... For this issue, make `__STDC_VERSION__ >= 201112L` a requirement in all cases.